### PR TITLE
Add pyproject.toml for Custom Node Registry

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,15 @@
+[project]
+name = "comfyui_cartoonsegmentation"
+description = "Front end ComfyUI nodes for CartoonSegmentation Based upon the work of the CartoonSegmentation repository this project will provide a front end to some of the features."
+version = "1.0.0"
+license = "LICENSE"
+dependencies = ["torch==2.1.1 --index-url https://download.pytorch.org/whl/cu118", "torchvision==0.16.1 --index-url https://download.pytorch.org/whl/cu118", "torchaudio==2.1.1 --index-url https://download.pytorch.org/whl/cu118", "mmcv==2.1.0", "omegaconf", "pydensecrf @ git+https://github.com/lucasb-eyer/pydensecrf.git", "numba", "wheel==0.42.0", "cupy==12.3.0", "mmdet", "imageio", "pandas", "onnxruntime", "pytorch_lightning", "moviepy", "gomp", "panopticapi @ git+https://github.com/cocodataset/panopticapi.git", "albumentations==1.1.0", "imgaug", "basicsr", "timm==0.6.7", "## Comfy Requirements", "safetensors", "psutil", "einops", "transformers", "scipy", "torchsde", "## Comfy Note to use requirment.txt", "aiohttp"]
+
+[project.urls]
+Repository = "https://github.com/Nlar/ComfyUI_CartoonSegmentation"
+#  Used by Comfy Registry https://comfyregistry.org
+
+[tool.comfy]
+PublisherId = ""
+DisplayName = "ComfyUI_CartoonSegmentation"
+Icon = ""


### PR DESCRIPTION
We are working with dr.lt.data and comfyanon to build a global registry for custom nodes (similar to PyPI). Eventually, the registry will be used as a backend for the UI-manager. All nodes go through a verification process before being published to users.

The main benefits are that authors can
- publish nodes by version and users can safely update nodes knowing ahead of time if their workflows will break or not
- automate testing against new commits in the comfy repo and existing workflows through our CI/CD dashboard

Action Required:

- [ ] Go to the [registry](https://registry.comfy.org). Login and create a publisher id. Add the publisher id into the pyproject.toml file.
- [ ] Write a short description.
- [ ] Merge the separate Github Actions PR and run the workflow.

If you want to publish the node manually, [install the cli](https://docs.comfy.org/comfy-cli/getting-started#install-cli) and run `comfy node publish`

Check out our [docs](https://docs.comfy.org/registry/overview#introduction) if you want to know more about the registry. Otherwise, feel free to message me on discord at haohao_81202 or join our [server](https://discord.com/invite/comfyorg) if you have any questions!